### PR TITLE
tamago-build: allow docker-based compilation via tamago build

### DIFF
--- a/tamago-build/README.md
+++ b/tamago-build/README.md
@@ -1,0 +1,34 @@
+# Tamago Build
+
+A docker-based build system for cross-compiling Go applications for ARM SoCs.
+
+```bash
+$ go install github.com/f-secure-foundry/tamago-go/tamago-build/tbd
+
+$ cd path/to/go/app
+$ tbd
+Usage: tbd <target-device> [output-path] [path-to-main-package]
+
+$ tbd rpi /Volumes/sd-card cmd/app-name
+rpi: Pulling from f-secure-foundry/tamago-go
+Status: Image is up to date for f-secure-foundry/tamago-go:rpi
+=> Downloading RPi firmware:
+   LICENCE.broadcom, bootcode.bin, fixup.dat, start.elf
+=> Building Go Application
+   go: downloading github.com/f-secure-foundry/tamago v0.0.0-20210601073428-3d51445fa773
+=> Preparing kernel file
+=> Build successful!
+```
+
+## How it works
+
+The `tbd` program is a purpose-built docker client which pulls and runs the tamago-build docker image for the specified target with the appropriate arguments.
+
+The tamago-build docker images are specific to each build target (currently only `rpi` exists). They use tamago-go to compile the given Go application for ARM SoCs, using [multiarch/crossbuild](https://github.com/multiarch/crossbuild) for cross compilation tooling to provide the kernel and boot files needed for the built output to Just Work™. 
+
+## Further work
+
+Potential improvements:
+
+- Add Dockerfiles for the [other supported hardware](https://github.com/f-secure-foundry/tamago#supported-hardware)
+- Use a different image for cross-compilation tooling (multiarch/crossbuild is _large_)

--- a/tamago-build/rpi/Dockerfile
+++ b/tamago-build/rpi/Dockerfile
@@ -1,0 +1,18 @@
+# The version of Go used to compile tamago-go
+ARG BOOTSTRAP_GO_VERSION=1.16.4
+
+FROM golang:$BOOTSTRAP_GO_VERSION as go
+
+COPY / /usr/local/tamago-go
+RUN cd /usr/local/tamago-go/src && ./all.bash
+
+FROM multiarch/crossbuild
+
+COPY --from=go /usr/local/tamago-go /usr/local/tamago-go
+ENV TAMAGO=/usr/local/tamago-go/bin/go
+
+ENV CROSS_TRIPLE=arm-linux-gnueabi
+COPY /tamago-build/rpi /tamago-build/
+
+ENTRYPOINT ["crossbuild", "/tamago-build/build.sh"]
+CMD ["."]

--- a/tamago-build/rpi/boot.S
+++ b/tamago-build/rpi/boot.S
@@ -1,0 +1,9 @@
+    .global _boot
+
+    .text
+_boot:
+    LDR r1, addr
+    BX r1
+
+addr:
+    .word ENTRY_POINT

--- a/tamago-build/rpi/build.sh
+++ b/tamago-build/rpi/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+# Constants
+FIRMWAREURL="https://raw.githubusercontent.com/raspberrypi/firmware/master/boot/"
+KERNEL_ADDRESS=8000
+TEXT_START=00110000 # Space for interrupt vector, etc
+
+# Builder
+ROOT="$(pwd)"
+BUILD_DIR="${ROOT}/build"
+BUILD_TMP=$(mktemp -d)
+mkdir -p $BUILD_DIR
+
+if [[ -z "$1" || "$1" == "." ]]; then
+  SRC_DIR="${ROOT}"
+  APP="tamago-kernel"
+else
+  SRC_DIR="${ROOT}/$1"
+  [[ ! -d "$SRC_DIR" ]] && { echo "The file/directory specified doesn't exist: ${SRC_DIR}"; exit 1; }
+  APP=$(dirname "$1")
+fi
+
+title=false
+for firmware in LICENCE.broadcom bootcode.bin fixup.dat start.elf; do
+  firmware_dest="${BUILD_DIR}/${firmware}"
+  if [ ! -f "${firmware_dest}" ]; then
+    [[ $title = false ]] && printf "=> Downloading RPi firmware:\n   " && title=true || printf ", "
+    printf $firmware
+    curl --silent --output "${firmware_dest}" "${FIRMWAREURL}${firmware}";
+  fi
+done
+[[ $title = true ]] && echo
+
+export GO_EXTLINK_ENABLED=0
+export CGO_ENABLED=0
+export GOOS=tamago
+export GOARM=5
+export GOARCH=arm
+
+LDFLAGS="-s -w -T 0x${TEXT_START} -E _rt0_arm_tamago -R 0x1000 -X 'main.Build=tamago-build on $(/bin/date -u "+%Y-%m-%d %H:%M:%S")'"
+[[ -d "${SRC_DIR}/.git" ]] && LDFLAGS="${LDFLAGS} -X 'main.Revision=$(git rev-parse --short HEAD 2> /dev/null)'"
+
+echo "=> Building Go Application"
+/usr/local/tamago-go/bin/go build -ldflags "${LDFLAGS}" -o "${BUILD_TMP}/${APP}" "$SRC_DIR" 2>&1 | stdbuf -o0 nl -bn -w2
+
+echo "=> Preparing kernel file"
+objdump -D "${BUILD_TMP}/${APP}" > "${BUILD_TMP}/${APP}.list"
+objcopy -j .text -j .rodata -j .shstrtab -j .typelink \
+  -j .itablink -j .gopclntab -j .go.buildinfo -j .noptrdata -j .data \
+  -j .bss --set-section-flags .bss=alloc,load,contents \
+  -j .noptrbss --set-section-flags .noptrbss=alloc,load,contents\
+  "${BUILD_TMP}/${APP}" -O binary "${BUILD_TMP}/${APP}.o"
+
+ENTRY_POINT=$(readelf -e "${BUILD_TMP}/${APP}" | grep Entry | sed 's/.*\(0x[a-zA-Z0-9]*\).*/\1/')
+gcc -D ENTRY_POINT="${ENTRY_POINT}" -c /tamago-build/boot.S -o "${BUILD_TMP}/boot.o"
+
+objcopy "${BUILD_TMP}/boot.o" -O binary "${BUILD_TMP}/stub.o"
+
+# Truncate pads the stub out to correctly align the binary
+TRUNC=$(echo "ibase=16;${TEXT_START}-${KERNEL_ADDRESS}" | bc)
+truncate -s ${TRUNC} "${BUILD_TMP}/stub.o"
+
+cat "${BUILD_TMP}/stub.o" "${BUILD_TMP}/${APP}.o" > "${BUILD_DIR}/${APP}.bin"
+
+cp "/tamago-build/config.txt" "${BUILD_DIR}/config.txt"
+echo "kernel_address=0x${KERNEL_ADDRESS}" >> "${BUILD_DIR}/config.txt"
+echo "kernel=${APP}.bin" >> "${BUILD_DIR}/config.txt"
+
+rm -rf "${BUILD_TMP}"
+echo "=> Build successful!"

--- a/tamago-build/rpi/config.txt
+++ b/tamago-build/rpi/config.txt
@@ -1,0 +1,9 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+enable_uart=1
+uart_2ndstage=1
+dtparam=uart0=on
+disable_commandline_tags=1
+core_freq=250

--- a/tamago-build/tbd/main.go
+++ b/tamago-build/tbd/main.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/term"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+)
+
+const (
+	// workDir is the path the Dockerfile expects the project to exist at
+	workDir = "/workdir"
+	// buildDir is the path the Dockerfile will output the built artefacts to
+	buildDir = "/workdir/build"
+	// tamagoBuildDockerProject is the project name on Docker Hub
+	tamagoBuildDockerProject = "f-secure-foundry/tamago-go"
+	// containerName is the name of the container to create
+	containerName = "tamago-build"
+)
+
+func main() {
+	if len(os.Args) <= 1 || os.Args[1] == "--help" {
+		exitWithUsage()
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		exitWithError("Couldn't discover current working directory: %v\n", err)
+	}
+
+	docker, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		exitWithError("Couldn't connect to Docker: %n\n", err)
+	}
+
+	target := os.Args[1]
+
+	mainPath := "."
+	if len(os.Args) >= 4 {
+		mainPath = os.Args[3]
+	}
+
+	mounts := []mount.Mount{{
+		Type:   mount.TypeBind,
+		Source: pwd,
+		Target: workDir,
+	}}
+
+	if len(os.Args) >= 3 {
+		outPath := os.Args[2]
+		if !dirIsPresent(outPath) {
+			exitWithError("Given output directory (%s) isn't present. Do you need to mount your SD card?", outPath)
+		}
+
+		mounts = append(mounts, mount.Mount{
+			Type:   mount.TypeBind,
+			Source: outPath,
+			Target: buildDir,
+		})
+	}
+
+	if err := run(docker, target, mainPath, mounts); err != nil {
+		exitWithError("Build failed: %v\n", err)
+	}
+}
+
+func run(docker *client.Client, target, mainPath string, mounts []mount.Mount) error {
+	imageName := tamagoBuildDockerProject + ":" + target
+	ctx := context.Background()
+	if err := pullImage(docker, ctx, imageName, false); err != nil {
+		return err
+	}
+
+	config := &container.Config{
+		Image: imageName,
+		Cmd:   []string{mainPath},
+		Tty:   false,
+	}
+	hostConfig := &container.HostConfig{
+		AutoRemove: true,
+		Mounts:     mounts,
+	}
+
+	c, err := docker.ContainerCreate(ctx, config, hostConfig, nil, nil, containerName+"."+target)
+	if err != nil {
+		return fmt.Errorf("couldn't create a tamago-build container\n%w", err)
+	}
+
+	if err := docker.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
+		return fmt.Errorf("couldn't start the tamago-build container\n%w", err)
+	}
+
+	if out, err := docker.ContainerLogs(ctx, c.ID, types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true, Follow: true}); err == nil {
+		_, _ = stdcopy.StdCopy(os.Stdout, os.Stderr, out)
+	}
+
+	return nil
+}
+
+func pullImage(docker *client.Client, ctx context.Context, imageName string, useCache bool) error {
+	query := filters.NewArgs()
+	query.Add("reference", imageName)
+
+	if useCache {
+		cs, err := docker.ImageList(ctx, types.ImageListOptions{Filters: query})
+		if err != nil {
+			return fmt.Errorf("Couldn't search local docker for the required image\n%w", err)
+		}
+		if len(cs) > 0 {
+			// The right image is already present
+			return nil
+		}
+	}
+
+	progress, err := docker.ImagePull(ctx, imageName, types.ImagePullOptions{})
+	if err != nil {
+		return fmt.Errorf("couldn't find tamago build image (%s)\n%w", imageName, err)
+	}
+	printProgress(progress)
+
+	return nil
+}
+
+func printProgress(reader io.ReadCloser) {
+	defer reader.Close()
+	termFd, isTerm := term.GetFdInfo(os.Stderr)
+	_ = jsonmessage.DisplayJSONMessagesStream(reader, os.Stderr, termFd, isTerm, nil)
+}
+
+func dirIsPresent(path string) bool {
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return fileInfo.IsDir()
+}
+
+func exitWithUsage() {
+	fmt.Printf("Usage: %s <target-device> [output-path] [path-to-main-package]\n", filepath.Base(os.Args[0]))
+	os.Exit(1)
+}
+
+func exitWithError(msg string, args ...interface{}) {
+	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
I've introduced a system for using Tamago Build with Docker — it uses containerisation to cross-compile Go applications for ARM SoCs using tamago.

```bash
$ go install github.com/jphastings/tamago-go/tamago-build/tbd

$ cd path/to/go/app
$ tbd
Usage: tbd <target-device> [output-path] [path-to-main-package]

$ tbd rpi /Volumes/sd-card cmd/app-name
rpi: Pulling from jphastings/tamago-go
Status: Image is up to date for jphastings/tamago-go:rpi
=> Downloading RPi firmware:
   LICENCE.broadcom, bootcode.bin, fixup.dat, start.elf
=> Building Go Application
   go: downloading github.com/f-secure-foundry/tamago v0.0.0-20210601073428-3d51445fa773
=> Preparing kernel file
=> Build successful!
```
This example uses `jphastings/tamago-go`, which you can try with right now, but the code in this PR is configured to use this repo, `f-secure-foundry/tamago-go`.

I have Docker hub set up to autobuild like this, assuming that you always release new versions of tamago-go with each new github tag of the form `tamagoX.Y.Z`. (Dockerfile location is `/tamago-build/rpi/Dockerfile`)

<img width="1185" alt="docker-autobuild" src="https://user-images.githubusercontent.com/42999/120839175-87c06f80-c560-11eb-833c-882bee296ecd.png">

