### PR TITLE
syscall: create fs.go and move DevFile interface to it

### DIFF
--- a/src/syscall/fs.go
+++ b/src/syscall/fs.go
@@ -1,0 +1,16 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file contains tamaga-defined interfaces that could run in non-Tamago contexts.
+// For example, on the t9 unikernel, some drivers can run in the host as well as
+// on tamago, and they must implement the DevFile interface.
+
+package syscall
+
+// DevFile is the implementation required of device files
+// like /dev/null or /dev/random.
+type DevFile interface {
+	Pread([]byte, int64) (int, error)
+	Pwrite([]byte, int64) (int, error)
+}

--- a/src/syscall/fs_tamago.go
+++ b/src/syscall/fs_tamago.go
@@ -35,13 +35,6 @@ type fsys struct {
 	dev  []func() (DevFile, error) // table for opening devices
 }
 
-// DevFile is the implementation required of device files
-// like /dev/null or /dev/random.
-type DevFile interface {
-	Pread([]byte, int64) (int, error)
-	Pwrite([]byte, int64) (int, error)
-}
-
 // An inode is a (possibly special) file in the file system.
 type inode struct {
 	Stat_t


### PR DESCRIPTION
syscall: create fs.go and move DevFile interface to it

The t9 unikernel has drivers that run both in tamago environments
and host environments. The DevFile interface is required in both
environments.

Create fs.go, and move the DevFile interface to it.