### PR TITLE
syscall: add a SIGABRT compatibility stub

### DIFF
--- a/src/syscall/syscall_tamago.go
+++ b/src/syscall/syscall_tamago.go
@@ -100,6 +100,7 @@ const (
 	SIGTRAP
 	SIGQUIT
 	SIGTERM
+	SIGABRT
 )
 
 func (s Signal) Signal() {}


### PR DESCRIPTION
This adds a SIGABRT compatibility stub to the existing list.

It's primarily being added to allow Tamago to continue to compiling apps which rely on the `glog` package.

