### PR TITLE
arm: fix initialization

### DIFF
--- a/src/runtime/rt0_tamago_arm.s
+++ b/src/runtime/rt0_tamago_arm.s
@@ -9,7 +9,7 @@
 TEXT _rt0_arm_tamago(SB),NOSPLIT|NOFRAME,$0
 	// cpuinit must be provided externally by the linked application for
 	// CPU initialization, it must call _rt0_tamago_start at completion
-	BL.EQ	cpuinit(SB)
+	B	cpuinit(SB)
 
 TEXT _rt0_tamago_start(SB),NOSPLIT|NOFRAME,$0
 	MOVW	runtime·ramStart(SB), R13


### PR DESCRIPTION
Fixes a bug introduced by the following commit.

commit 631b797be80e4236ab31dd98cdf8f1aba098378a
Author: Andrea Barisani <andrea@inversepath.com>
Date:   Wed Oct 1 13:53:12 2025 +0200

    move GOOS=tamago initialization under test runs in testing package